### PR TITLE
s/lpthread/pthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ then
 fi
 
 AC_CHECK_LIB(jansson, json_loads, request_jansson=false, request_jansson=true)
-AC_CHECK_LIB([pthread], [pthread_create], PTHREAD_LIBS="-lpthread",
+AC_CHECK_LIB([pthread], [pthread_create], PTHREAD_LIBS="-pthread",
   AC_CHECK_LIB([pthreadGC2], [pthread_create], PTHREAD_LIBS="-lpthreadGC2",
     AC_CHECK_LIB([pthreadGC1], [pthread_create], PTHREAD_LIBS="-lpthreadGC1",
       AC_CHECK_LIB([pthreadGC], [pthread_create], PTHREAD_LIBS="-lpthreadGC"


### PR DESCRIPTION
lpthread shouldn't be used. -pthread is correct.  I'm uncertain about the remaining ones.
