### PR TITLE
Recognize FreeBSD i386/amd64 installs as 86/86_64 arches.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,10 @@ case $target in
     have_x86=true
     have_x86_64=true
     ;;
+  amd64-*-*)
+    have_x86=true
+    have_x86_64=true
+    ;;
 esac
 
 PTHREAD_FLAGS="-pthread"


### PR DESCRIPTION
This allows FreeBSD installs to have AVX/XOP support without any
significant modifications -- it should be noted that the base install of
gcc doesn't actually have support, but a later version from ports can be
installed by the user and chosen via e.g., `CC=/usr/local/bin/gcc48`.
