### PR TITLE
fix sched_setaffinity parameter : sizeof(cpu_set_t)

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -62,7 +62,7 @@ static inline void affine_to_cpu(int id, int cpu)
 
 	CPU_ZERO(&set);
 	CPU_SET(cpu, &set);
-	sched_setaffinity(0, sizeof(&set), &set);
+	sched_setaffinity(0, sizeof(set), &set);
 }
 #elif defined(__FreeBSD__) /* FreeBSD specific policy and affinity management */
 #include <sys/cpuset.h>


### PR DESCRIPTION
Fixes the size of cpu_set_t set parameter of sched_setaffinity(...).
The bug can be seen only if more than 64 cpus on a 64bit architecture (such as Intel Xeon Phi)
