### PR TITLE
Hide password on the command line

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1094,6 +1094,7 @@ static void parse_arg (int key, char *arg)
 	case 'p':
 		free(rpc_pass);
 		rpc_pass = strdup(arg);
+		while (*arg) *arg++= 'x'; /* hide password */
 		break;
 	case 'P':
 		opt_protocol = true;


### PR DESCRIPTION
I wanted to make the miner a little more friendly when run on a multi-user system. This change hides the password when it is viewed by 'ps'.
