### PR TITLE
Add coinbase checking for pool mining

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1705,12 +1705,15 @@ static void parse_arg(int key, char *arg, char *pname)
 				pname);
 			show_usage_and_exit(1);
 		}
-		if (arg[0] != '>' && arg[0] != '<' && arg[0] != '=') {
+		if (arg[0] != '>' && arg[0] != '+' &&
+			arg[0] != '<' && arg[0] != '-' &&
+			arg[0] != '=') {
 			fprintf(stderr, "%s: invalid coinbase-perc op -- '%s'\n", pname,
 				arg);
 			show_usage_and_exit(1);
 		}
-		coinbase_perc_op.op = arg[0];
+		coinbase_perc_op.op = (arg[0] == '+' ? '>' :
+								(arg[0] == '-' ? '<' : arg[0]));
 		coinbase_perc_op.value = atof(&arg[1]);
 		break;
 	case 1015:			/* --coinbase-sig */

--- a/miner.h
+++ b/miner.h
@@ -231,6 +231,8 @@ extern int timeval_subtract(struct timeval *result, struct timeval *x,
 	struct timeval *y);
 extern bool fulltest(const uint32_t *hash, const uint32_t *target);
 extern void diff_to_target(uint32_t *target, double diff);
+extern bool check_coinbase(const unsigned char *coinbase, size_t cbsize,
+	struct compare_op* cop, const unsigned char *pk_script, size_t pk_script_size);
 
 struct stratum_job {
 	char *job_id;

--- a/util.c
+++ b/util.c
@@ -766,7 +766,6 @@ static bool test_address( char *addr, size_t *addrsz, unsigned char ver, const u
 
 size_t script_to_address(char *out, size_t outsz, const unsigned char *script, size_t scriptsz, bool testnet)
 {
-	unsigned char buf[32], hret[32];
 	char addr[35];
 	size_t size = sizeof(addr);
 	bool bok = false;


### PR DESCRIPTION
In stratum pool mining mode, the pool sends mining_notify message to distribute job, however, to reduce bandwidth usage, there is no transaction list included in the message, the miner would have to ask for it explicitly by sending a get_transactions message if desired, that in effect loses the bandwidth saving of stratum protocol, which actually is the essence.

By adding a coinbase checking function, we can possibly obsolete the necessary of get_transactions message during most circumstance:
    1. We ensure this is a valid BTC coinbase for btc, so reduce the possibility of pool stealing power for other kind of work;
    2. We check amount and to-address by going through the whole payout list, so reduce the possibility of pool stealing the coins mined;
    3. We can even specify the percent regards how much pool can gain from this mining job, so reduce the possibility of pool transferring (part of) coins mined;

The coinbase checking can not totally replace get_transactions message, but combined with other human actions it can give miners‘ enough confidence to trust a pool.

The usage is pretty straightforward: input --coinbase-perc argument with --coinbase-addr, e.g.: --coinbase-perc='=1', or --coinbase-perc='>0.99', or --coinbase-perc='<0.05', etc, the command will ensure the addr specified by --coinbase-addr get corresponding percent of all benefit.

Sign-off-by: Huang Le 4tarhl@gmail.com
