### PR TITLE
Modified Dockerfile and Ubuntu Version to 14.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,18 @@
 #
 #
 
-FROM		ubuntu:12.10
-MAINTAINER	Guillaume J. Charmes <guillaume@charmes.net>
+FROM            ubuntu:14.04
+MAINTAINER      Guillaume J. Charmes <guillaume@charmes.net>
 
-RUN		apt-get update -qq
+RUN             apt-get update -qq && \
+                apt-get install -qqy automake libcurl4-openssl-dev git make
 
-RUN		apt-get install -qqy automake
-RUN		apt-get install -qqy libcurl4-openssl-dev
-RUN		apt-get install -qqy git
-RUN		apt-get install -qqy make
+RUN             git clone https://github.com/pooler/cpuminer
 
-RUN		git clone https://github.com/pooler/cpuminer
+RUN             cd cpuminer && \
+                ./autogen.sh && \
+                ./configure CFLAGS="-O3" && \
+                make
 
-RUN		cd cpuminer && ./autogen.sh
-RUN		cd cpuminer && ./configure CFLAGS="-O3"
-RUN		cd cpuminer && make
-
-WORKDIR		/cpuminer
-ENTRYPOINT	["./minerd"]
+WORKDIR         /cpuminer
+ENTRYPOINT      ["./minerd"]


### PR DESCRIPTION
Modified Dockerfile to reduce the Virtual Memory footprint and total amount of images.

Due to the RUN statements in the original Dockerfile the total memory footprint was around 3GB of images. I have reduced the 9 RUN statements down to 3 and this has now reduced the total images size to less than 50% (~1.4GB)

In additional bumped from 12.10 to 14.04

I found the apt-get update was not working correcting for 12.10 due to repository list. I swapped across to 14.04, however further testing will needed to confirm it works running in a live environment.