### PR TITLE
Add small disclaimer for ./configure flag

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,7 @@ Dependencies:
 Basic *nix build instructions:
 	./autogen.sh	# only needed if building from git repo
 	./nomacro.pl	# only needed if building on Mac OS X or with Clang
-	./configure CFLAGS="-O3"
+	./configure CFLAGS="-O3" # Make sure -O3 is an O and not a zero!
 	make
 
 Notes for AIX users:


### PR DESCRIPTION
Added a comment to make sure the user isn't accidently typing -03 instead of -O3.