### PR TITLE
Update Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ EXTRA_DIST	= example-cfg.json nomacro.pl
 
 SUBDIRS		= compat
 
-INCLUDES	= $(PTHREAD_FLAGS) -fno-strict-aliasing $(JANSSON_INCLUDES)
+AM_CPPFLAGS	= $(PTHREAD_FLAGS) -fno-strict-aliasing $(JANSSON_INCLUDES)
 
 bin_PROGRAMS	= minerd
 


### PR DESCRIPTION
Fixed linux build error when trying to LIBCURL_CHECK_CONFIG (INCLUDES is the deprecated version of AM_CPPFLAGS).