### PR TITLE
glibc < 2.13 compatibility patch

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -38,6 +38,22 @@
 #include "compat.h"
 #include "miner.h"
 
+#ifdef __hppa__
+# ifndef MADV_HUGEPAGE
+#  define MADV_HUGEPAGE		67
+# endif
+# ifndef MADV_NOHUGEPAGE
+#  define MADV_NOHUGEPAGE	68
+# endif
+#else
+# ifndef MADV_HUGEPAGE
+#  define MADV_HUGEPAGE		14
+# endif
+# ifndef MADV_NOHUGEPAGE
+#  define MADV_NOHUGEPAGE	15
+# endif
+#endif
+
 #define PROGRAM_NAME		"minerd"
 #define LP_SCANTIME		60
 


### PR DESCRIPTION
Add the MADV_NOHUGEPAGE and MADV_HUGEPAGE constants to enable compilation from glibc older than 2.13 and kernel prior to 2.6.38. 
See here https://lkml.org/lkml/2013/3/18/212