### PR TITLE
Add a new CLI option `-M` or `--max-diff` for limiting mining to low-difficulty periods

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([cpuminer], [2.5.0])
+AC_INIT([cpuminer], [2.5.0-maxdiff])
 
 AC_PREREQ([2.59c])
 AC_CANONICAL_SYSTEM

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([cpuminer], [2.5.1-maxdiff])
+AC_INIT([cpuminer], [2.5.1])
 
 AC_PREREQ([2.59c])
 AC_CANONICAL_SYSTEM

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1226,12 +1226,12 @@ static void *miner_thread(void *userdata)
 			switch (opt_algo) {
 			case ALGO_SCRYPT:
 				rc = scanhash_scrypt(thr_id, work.data, scratchbuf, work.target,
-									max_nonce, &hashes_done, opt_scrypt_n);
+				                     max_nonce, &hashes_done, opt_scrypt_n);
 				break;
 
 			case ALGO_SHA256D:
 				rc = scanhash_sha256d(thr_id, work.data, work.target,
-									max_nonce, &hashes_done);
+				                      max_nonce, &hashes_done);
 				break;
 
 			default:
@@ -1774,23 +1774,23 @@ static void parse_arg(int key, char *arg, char *pname)
 		strcpy(coinbase_sig, arg);
 		break;
 	case 'M': {			/* --max-diff */
-			char *colon;
-			if (sscanf(arg, "%lf", &max_diff) != 1 || max_diff <= 1.0) {
-				fprintf(stderr, "%s: invalid --max-diff: %s\n", pname, arg);
+		char *colon;
+		if (sscanf(arg, "%lf", &max_diff) != 1 || max_diff <= 1.0) {
+			fprintf(stderr, "%s: invalid --max-diff: %s\n", pname, arg);
+			show_usage_and_exit(1);
+		}
+		// Optional second component to arg e.g. "10.0:5" where 5 here
+		// is the time to sleep.
+		if ((colon = strchr(arg, ':'))) {
+			if (sscanf(++colon, "%d", &max_diff_backoff_secs) != 1
+			    || max_diff_backoff_secs < 1) {
+				fprintf(stderr, "%s: invalid backoff time specified for"
+				        " --max-diff: %s\n", pname, colon);
 				show_usage_and_exit(1);
-			}
-			// Optional second component to arg e.g. "10.0:5" where 5 here
-			// is the time to sleep.
-			if ((colon = strchr(arg, ':'))) {
-				if (sscanf(++colon, "%d", &max_diff_backoff_secs) != 1
-						|| max_diff_backoff_secs < 1) {
-					fprintf(stderr, "%s: invalid backoff time specified for"
-					                " --max-diff: %s\n", pname, colon);
-					show_usage_and_exit(1);
-				}
 			}
 		}
 		break;
+	}
 	case 'S':
 		use_syslog = true;
 		break;

--- a/miner.h
+++ b/miner.h
@@ -206,6 +206,8 @@ extern int timeval_subtract(struct timeval *result, struct timeval *x,
 	struct timeval *y);
 extern bool fulltest(const uint32_t *hash, const uint32_t *target);
 extern void diff_to_target(uint32_t *target, double diff);
+/* Return the network difficulty from the work.data[18] bits as a double. */
+extern double diff_from_nbits(const void *nbits);
 
 struct stratum_job {
 	char *job_id;

--- a/util.c
+++ b/util.c
@@ -80,7 +80,7 @@ void applog(int prio, const char *fmt, ...)
 		va_list ap2;
 		char *buf;
 		int len;
-		
+
 		va_copy(ap2, ap);
 		len = vsnprintf(NULL, 0, fmt, ap2) + 1;
 		va_end(ap2);
@@ -228,7 +228,7 @@ static size_t upload_data_cb(void *ptr, size_t size, size_t nmemb,
 static int seek_data_cb(void *user_data, curl_off_t offset, int origin)
 {
 	struct upload_buffer *ub = user_data;
-	
+
 	switch (origin) {
 	case SEEK_SET:
 		ub->pos = offset;
@@ -855,7 +855,7 @@ bool fulltest(const uint32_t *hash, const uint32_t *target)
 {
 	int i;
 	bool rc = true;
-	
+
 	for (i = 7; i >= 0; i--) {
 		if (hash[i] > target[i]) {
 			rc = false;
@@ -870,7 +870,7 @@ bool fulltest(const uint32_t *hash, const uint32_t *target)
 	if (opt_debug) {
 		uint32_t hash_be[8], target_be[8];
 		char hash_str[65], target_str[65];
-		
+
 		for (i = 0; i < 8; i++) {
 			be32enc(hash_be + i, hash[7 - i]);
 			be32enc(target_be + i, target[7 - i]);
@@ -892,7 +892,7 @@ void diff_to_target(uint32_t *target, double diff)
 {
 	uint64_t m;
 	int k;
-	
+
 	for (k = 6; k > 0 && diff > 1.0; k--)
 		diff /= 4294967296.0;
 	m = 4294901760.0 / diff;
@@ -905,6 +905,25 @@ void diff_to_target(uint32_t *target, double diff)
 	}
 }
 
+double diff_from_nbits(const void *nbits_in)
+{
+	double numerator;
+	uint32_t diff32;
+	uint8_t pow;
+	int powdiff;
+	const uint32_t possibly_unswabbed_bits = le32dec(nbits_in);
+	const uint8_t * const nbits = (const uint8_t *)&possibly_unswabbed_bits;
+
+	pow = nbits[0];
+	powdiff = (8 * (0x1d - 3)) - (8 * (pow - 3));
+	if (powdiff < 0) // testnet only
+		powdiff = 0;
+	diff32 = be32dec(nbits) & 0x00FFFFFF;
+	numerator = 0xFFFFULL << powdiff;
+
+	return numerator / (double)diff32;
+}
+
 #ifdef WIN32
 #define socket_blocks() (WSAGetLastError() == WSAEWOULDBLOCK)
 #else
@@ -914,7 +933,7 @@ void diff_to_target(uint32_t *target, double diff)
 static bool send_line(struct stratum_ctx *sctx, char *s)
 {
 	ssize_t len, sent = 0;
-	
+
 	len = strlen(s);
 	s[len++] = '\n';
 
@@ -1471,7 +1490,7 @@ static bool stratum_get_version(struct stratum_ctx *sctx, json_t *id)
 	char *s;
 	json_t *val;
 	bool ret;
-	
+
 	if (!id || json_is_null(id))
 		return false;
 
@@ -1496,7 +1515,7 @@ static bool stratum_show_message(struct stratum_ctx *sctx, json_t *id, json_t *p
 	val = json_array_get(params, 0);
 	if (val)
 		applog(LOG_NOTICE, "MESSAGE FROM SERVER: %s", json_string_value(val));
-	
+
 	if (!id || json_is_null(id))
 		return true;
 


### PR DESCRIPTION
This PR is in reference to #193 .

I added a CLI option for limiting when the miner actually mines to when difficulty falls below a certain threshold (default: infinite difficulty).  If the work unit's difficulty is below a certain threshold, then the miner will sleep for T seconds (T can be specified as well).  

The format of the option is: `-M N[:T]`  (the `:T` part is optional).  Where N=mindiff threshold and T is seconds to sleep before trying again (default 10 seconds if  unspecified).  E.g.:

`./minerd -M 123.5`  <-- iff difficulty dips below 123.5, we sleep for 10 seconds, wake up, look if a new work unit has arrived, sleep again, etc.

`./minerd -M 5:3` <-- iff difficulty dips below 5, we sleep for 3 seconds and try again.

I find this option is very useful for sha256d testnet mining where you want to wait for difficulty to drop to 1.0 (the 20 minute rule on bitcoin or on bitcoin cash or on bitcoin sv) before mining.  Often difficulty for cpu mining on testnet is very high and you can only really mine when diff=1.0.  Otherwise you are just burning your CPU needlessly.

Sample output. Running with debug logging and `-M 1.0:3`:

```
[2020-08-20 19:53:21] thread 0: 2589.8 > max_diff 1.0, sleeping 3 secs
[2020-08-20 19:53:22] < {"params":["5f31ec7100014b31","6c4b9aaa055630c710df6ab6cd54f602856de440b422262b000c70f100000000","01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2c03a968152f43616c696e277320546573744e657420506f6f6c202d20506f7765726564206279204243484e2fffffffff03c2eb0b00000000001976a9140a373caf0ab3c2b46cd05625b8d545c295b93d7a88ac062c9c04000000001976a9148fc9c85983583e959cc13b6898932f3b14eec88488ac0000000000000000166a14","ef8ce88bf501000000000000",[],"20000000","1b194e32","5f3eaa88",false],"id":null,"method":"mining.notify"}
[2020-08-20 19:53:22] DEBUG: job_id='5f31ec7100014b31' extranonce2=0000000000000000 ntime=5f3eaa88
[2020-08-20 19:53:24] thread 2: 0 hashes, 0.00 khash/s
[2020-08-20 19:53:24] thread 2: 2589.8 > max_diff 1.0, sleeping 3 secs
```
