### PR TITLE
Set coinbase version to 2

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -463,7 +463,7 @@ static bool gbt_work_decode(const json_t *val, struct work *work)
 		}
 		cbvalue = json_is_integer(tmp) ? json_integer_value(tmp) : json_number_value(tmp);
 		cbtx = malloc(256);
-		le32enc((uint32_t *)cbtx, 1); /* version */
+		le32enc((uint32_t *)cbtx, 2); /* version */
 		cbtx[4] = 1; /* in-counter */
 		memset(cbtx+5, 0x00, 32); /* prev txout hash */
 		le32enc((uint32_t *)(cbtx+37), 0xffffffff); /* prev txout index */


### PR DESCRIPTION
BIP68 doesn't require transactions to use version 2, but why not.